### PR TITLE
Update S7Connection.cs

### DIFF
--- a/Sally7/S7Connection.cs
+++ b/Sally7/S7Connection.cs
@@ -103,9 +103,9 @@ namespace Sally7
             await openAsync();
         }
 
-        public async Task OpenAsync(double connectionTimeout)
+        public async Task OpenAsync(TimeSpan connectionTimeout)
         {
-            var cancelTask = Task.Delay(TimeSpan.FromMilliseconds(connectionTimeout));
+            var cancelTask = Task.Delay(connectionTimeout);
             var connectTask = TcpClient.ConnectAsync(host, IsoOverTcpPort);
 
             if (await Task.WhenAny(connectTask, cancelTask).ConfigureAwait(false) == cancelTask)


### PR DESCRIPTION
Modification to set a timeout for the OpenAsync

I noticed that this function takes a while when the destination IP address is not reachable.
I think it will be nice if we can set a Timeout parameter for this function.