### PR TITLE
Removes the in modifier, as it's not needed and harms perf by passing as (readonly) reference

### DIFF
--- a/Sally7/DataBlockDataItem.cs
+++ b/Sally7/DataBlockDataItem.cs
@@ -28,7 +28,7 @@ namespace Sally7
             }
         }
 
-        private DataBlockDataItem(in ConvertToS7<TValue> toS7Converter, in ConvertFromS7<TValue> fromS7Converter, in int elementSize)
+        private DataBlockDataItem(ConvertToS7<TValue> toS7Converter, ConvertFromS7<TValue> fromS7Converter, int elementSize)
         {
             this.toS7Converter = toS7Converter;
             this.fromS7Converter = fromS7Converter;
@@ -75,11 +75,11 @@ namespace Sally7
         TransportSize IDataItem.TransportSize => transportSize;
         VariableType IDataItem.VariableType => variableType;
 
-        int IDataItem.WriteValue(in Span<byte> output) => toS7Converter.Invoke(value, Length, output);
+        int IDataItem.WriteValue(Span<byte> output) => toS7Converter.Invoke(value, Length, output);
 
-        void IDataItem.ReadValue(in ReadOnlySpan<byte> input) => fromS7Converter.Invoke(ref value, input, Length);
+        void IDataItem.ReadValue(ReadOnlySpan<byte> input) => fromS7Converter.Invoke(ref value, input, Length);
 
-        private void SetLength(in int newLength)
+        private void SetLength(int newLength)
         {
             if (length == newLength) return;
 

--- a/Sally7/IDataItem.cs
+++ b/Sally7/IDataItem.cs
@@ -14,8 +14,8 @@ namespace Sally7
         TransportSize TransportSize { get; }
         VariableType VariableType { get; }
 
-        int WriteValue(in Span<byte> output);
-        void ReadValue(in ReadOnlySpan<byte> input);
+        int WriteValue(Span<byte> output);
+        void ReadValue(ReadOnlySpan<byte> input);
     }
 
     public interface IDataItem<TValue> : IDataItem

--- a/Sally7/Internal/SocketTpktReader.cs
+++ b/Sally7/Internal/SocketTpktReader.cs
@@ -62,7 +62,7 @@ namespace Sally7.Internal
             return receivedLength;
         }
 
-        private static int GetTpktLength(in ReadOnlySpan<byte> span)
+        private static int GetTpktLength(ReadOnlySpan<byte> span)
         {
             try
             {

--- a/Sally7/Protocol/BigEndianShort.cs
+++ b/Sally7/Protocol/BigEndianShort.cs
@@ -8,12 +8,12 @@ namespace Sally7.Protocol
         public byte High;
         public byte Low;
 
-        public static implicit operator BigEndianShort(in int value) =>
+        public static implicit operator BigEndianShort(int value) =>
             new BigEndianShort {High = (byte) (value >> 8), Low = (byte) value};
 
-        public static implicit operator BigEndianShort(in byte value) => new BigEndianShort {High = 0, Low = value};
+        public static implicit operator BigEndianShort(byte value) => new BigEndianShort {High = 0, Low = value};
 
-        public static implicit operator int(in BigEndianShort ns) => ns.High << 8 | ns.Low;
+        public static implicit operator int(BigEndianShort ns) => ns.High << 8 | ns.Low;
 
         public override string ToString() => ((int) this).ToString();
     }

--- a/Sally7/Protocol/Cotp/Messages/ConnectionRequestMessage.cs
+++ b/Sally7/Protocol/Cotp/Messages/ConnectionRequestMessage.cs
@@ -15,7 +15,7 @@ namespace Sally7.Protocol.Cotp.Messages
         public TsapParameter SourceTsapParameter;
         public TsapParameter DestinationTsapParameter;
         
-        public void Init(in PduSizeParameter.PduSize pduSize, in Tsap sourceTsap, in Tsap destinationTsap)
+        public void Init(PduSizeParameter.PduSize pduSize, Tsap sourceTsap, Tsap destinationTsap)
         {
             Length = (byte) (Size - 1);
             ConnectionRequest.Init();

--- a/Sally7/Protocol/Cotp/PduSizeParameter.cs
+++ b/Sally7/Protocol/Cotp/PduSizeParameter.cs
@@ -9,7 +9,7 @@ namespace Sally7.Protocol.Cotp
         public byte Length;
         public PduSize Value;
 
-        public void Init(in PduSize pduSize)
+        public void Init(PduSize pduSize)
         {
             Code = ParameterCode.TpduSize;
             Value = pduSize;

--- a/Sally7/Protocol/Cotp/Tsap.cs
+++ b/Sally7/Protocol/Cotp/Tsap.cs
@@ -5,7 +5,7 @@ namespace Sally7.Protocol.Cotp
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct Tsap
     {
-        public Tsap(in byte channel, in byte position)
+        public Tsap(byte channel, byte position)
         {
             Channel = channel;
             Position = position;

--- a/Sally7/Protocol/Cotp/TsapParameter.cs
+++ b/Sally7/Protocol/Cotp/TsapParameter.cs
@@ -9,7 +9,7 @@ namespace Sally7.Protocol.Cotp
         public byte Length;
         public Tsap Tsap;
 
-        public void Init(in ParameterCode code, in Tsap tsap)
+        public void Init(ParameterCode code, Tsap tsap)
         {
             Code = code;
             Tsap = tsap;

--- a/Sally7/Protocol/IsoOverTcp/Tpkt.cs
+++ b/Sally7/Protocol/IsoOverTcp/Tpkt.cs
@@ -19,7 +19,7 @@ namespace Sally7.Protocol.IsoOverTcp
             if (Length.High == 0 && Length.Low < 7) throw new Exception("Spec violation: TPKT length is smaller than 7.");
         }
 
-        public void Init(in BigEndianShort length)
+        public void Init(BigEndianShort length)
         {
             Version = IsoVersion;
             Reserved = 0;

--- a/Sally7/Protocol/S7/Messages/CommunicationSetup.cs
+++ b/Sally7/Protocol/S7/Messages/CommunicationSetup.cs
@@ -13,7 +13,7 @@ namespace Sally7.Protocol.S7.Messages
         public BigEndianShort MaxAmqCallee;
         public BigEndianShort PduSize;
 
-        public void Init(in BigEndianShort maxAmqCaller, in BigEndianShort maxAmqCallee, in BigEndianShort pduSize)
+        public void Init(BigEndianShort maxAmqCaller, BigEndianShort maxAmqCallee, BigEndianShort pduSize)
         {
             FunctionCode = FunctionCode.CommunicationSetup;
             Reserved = 0;
@@ -22,7 +22,7 @@ namespace Sally7.Protocol.S7.Messages
             PduSize = pduSize;
         }
 
-        public readonly void Assert(in FunctionCode functionCode)
+        public readonly void Assert(FunctionCode functionCode)
         {
             if (FunctionCode != functionCode) throw new Exception($"Expected function code {functionCode}, received {FunctionCode}.");
             if (Reserved != 0) throw new Exception($"Expected reserved 0, received {Reserved}");

--- a/Sally7/Protocol/S7/Messages/Header.cs
+++ b/Sally7/Protocol/S7/Messages/Header.cs
@@ -14,7 +14,7 @@ namespace Sally7.Protocol.S7.Messages
         public HeaderErrorClass ErrorClass;
         public byte ErrorCode;
 
-        public void Init(in MessageType messageType, in BigEndianShort paramLength, in BigEndianShort dataLength)
+        public void Init(MessageType messageType, BigEndianShort paramLength, BigEndianShort dataLength)
         {
             ProtocolId = 0x32;
             MessageType = messageType;
@@ -25,7 +25,7 @@ namespace Sally7.Protocol.S7.Messages
             DataLength = dataLength;
         }
 
-        public readonly void Assert(in MessageType messageType)
+        public readonly void Assert(MessageType messageType)
         {
             if (ProtocolId != 0x32) throw new Exception($"Expected protocol ID {0x32}, received {ProtocolId}.");
             if (Reserved.High != 0 || Reserved.Low != 0)

--- a/Sally7/Protocol/S7/Messages/ReadRequest.cs
+++ b/Sally7/Protocol/S7/Messages/ReadRequest.cs
@@ -9,7 +9,7 @@ namespace Sally7.Protocol.S7.Messages
         public FunctionCode FunctionCode;
         public byte ItemCount;
 
-        public readonly void Assert(in byte count)
+        public readonly void Assert(byte count)
         {
             if (FunctionCode != FunctionCode.Read) throw new Exception($"Expected FunctionCode {FunctionCode.Read}, received {FunctionCode}.");
             if (ItemCount != count) throw new Exception($"Expected ItemCount {count}, received {ItemCount}.");

--- a/Sally7/S7Connection.cs
+++ b/Sally7/S7Connection.cs
@@ -10,7 +10,7 @@ using Sally7.RequestExecutor;
 
 namespace Sally7
 {
-    public class S7Connection : IDisposable
+    public sealed class S7Connection : IDisposable
     {
         private const int IsoOverTcpPort = 102;
 
@@ -43,7 +43,7 @@ namespace Sally7
         /// <param name="executorFactory">
         /// The factory used to create an executor after the connection is initialized.
         /// </param>
-        public S7Connection(in string host, in Tsap sourceTsap, in Tsap destinationTsap, in MemoryPool<byte>? memoryPool = default, in RequestExecutorFactory? executorFactory = default)
+        public S7Connection(string host, Tsap sourceTsap, Tsap destinationTsap, MemoryPool<byte>? memoryPool = default, RequestExecutorFactory? executorFactory = default)
         {
             this.host = host;
             this.sourceTsap = sourceTsap;
@@ -61,7 +61,7 @@ namespace Sally7
         /// <param name="host">The PLC host, specified as IP address or hostname.</param>
         /// <param name="sourceTsap">The local TSAP for the connection.</param>
         /// <param name="destinationTsap">The remote TSAP for the connection.</param>
-        public S7Connection(in string host, in Tsap sourceTsap, in Tsap destinationTsap) : this(host, sourceTsap,
+        public S7Connection(string host, Tsap sourceTsap, Tsap destinationTsap) : this(host, sourceTsap,
             destinationTsap, default)
         {
         }

--- a/Sally7/S7ConnectionHelpers.cs
+++ b/Sally7/S7ConnectionHelpers.cs
@@ -13,7 +13,7 @@ namespace Sally7
 {
     internal static class S7ConnectionHelpers
     {
-        public static int BuildConnectRequest(in Span<byte> buffer, in Tsap sourceTsap, in Tsap destinationTsap)
+        public static int BuildConnectRequest(Span<byte> buffer, Tsap sourceTsap, Tsap destinationTsap)
         {
             ref var message = ref buffer.Struct<ConnectionRequestMessage>(4);
             message.Init(PduSizeParameter.PduSize.Pdu1024, sourceTsap, destinationTsap);
@@ -23,7 +23,7 @@ namespace Sally7
             return len;
         }
 
-        public static int BuildCommunicationSetup(in Span<byte> buffer)
+        public static int BuildCommunicationSetup(Span<byte> buffer)
         {
             ref var data = ref buffer.Struct<Data>(4);
             data.Init();
@@ -41,7 +41,7 @@ namespace Sally7
             return len;
         }
 
-        public static int BuildReadRequest(in Span<byte> buffer, in IReadOnlyList<IDataItem> dataItems)
+        public static int BuildReadRequest(Span<byte> buffer, IReadOnlyList<IDataItem> dataItems)
         {
             ref var read = ref buffer.Struct<ReadRequest>(17);
             read.FunctionCode = FunctionCode.Read;
@@ -56,7 +56,7 @@ namespace Sally7
             return BuildS7JobRequest(buffer, dataItems.Count * 12 + 2, 0);
         }
 
-        public static int BuildWriteRequest(in Span<byte> buffer, in IReadOnlyList<IDataItem> dataItems)
+        public static int BuildWriteRequest(Span<byte> buffer, IReadOnlyList<IDataItem> dataItems)
         {
             var span = buffer.Slice(17); // Skip header
             span[0] = (byte) FunctionCode.Write;
@@ -99,7 +99,7 @@ namespace Sally7
             requestItem.VariableType = dataItem.VariableType;
         }
 
-        private static int BuildS7JobRequest(in Span<byte> buffer, in BigEndianShort parameterLength, in BigEndianShort dataLength)
+        private static int BuildS7JobRequest(Span<byte> buffer, BigEndianShort parameterLength, BigEndianShort dataLength)
         {
             var len = parameterLength + dataLength + 17; // Error omitted
             buffer.Struct<Tpkt>(0).Init(len);
@@ -109,7 +109,7 @@ namespace Sally7
             return len;
         }
 
-        public static void ParseConnectionConfirm(in ReadOnlySpan<byte> buffer)
+        public static void ParseConnectionConfirm(ReadOnlySpan<byte> buffer)
         {
             var fixedPartLength = buffer[5];
             if (fixedPartLength < ConnectionConfirm.Size)
@@ -121,7 +121,7 @@ namespace Sally7
             // Analyze returned parameters?
         }
 
-        public static void ParseCommunicationSetup(in ReadOnlySpan<byte> buffer, out int pduSize, out int maxNumberOfConcurrentRequests)
+        public static void ParseCommunicationSetup(ReadOnlySpan<byte> buffer, out int pduSize, out int maxNumberOfConcurrentRequests)
         {
             if (buffer.Length < 19 + CommunicationSetup.Size) throw new Exception("Received data is smaller than TPKT + DT PDU + S7 header + S7 communication setup size.");
             ref readonly var dt = ref buffer.Struct<Data>(4);
@@ -137,7 +137,7 @@ namespace Sally7
             maxNumberOfConcurrentRequests = s7CommunicationSetup.MaxAmqCaller;
         }
 
-        public static void ParseReadResponse(in ReadOnlySpan<byte> buffer, in IReadOnlyCollection<IDataItem> dataItems)
+        public static void ParseReadResponse(ReadOnlySpan<byte> buffer, IReadOnlyCollection<IDataItem> dataItems)
         {
             ref readonly var dt = ref buffer.Struct<Data>(4);
             dt.Assert();
@@ -186,7 +186,7 @@ namespace Sally7
             if (exceptions != null) throw new AggregateException(exceptions);
         }
 
-        public static void ParseWriteResponse(in ReadOnlySpan<byte> buffer, in IReadOnlyList<IDataItem> dataItems)
+        public static void ParseWriteResponse(ReadOnlySpan<byte> buffer, IReadOnlyList<IDataItem> dataItems)
         {
             ref readonly var dt = ref buffer.Struct<Data>(4);
             dt.Assert();

--- a/Sally7/ValueConversion/ConversionHelper.cs
+++ b/Sally7/ValueConversion/ConversionHelper.cs
@@ -8,7 +8,7 @@ namespace Sally7.ValueConversion
     {
         private static readonly MethodInfo sizeOfMethod = typeof(Unsafe).GetMethod(nameof(Unsafe.SizeOf));
 
-        public static int SizeOf(in Type type)
+        public static int SizeOf(Type type)
         {
             return (int) sizeOfMethod.MakeGenericMethod(type).Invoke(null, new object[0]);
         }

--- a/Sally7/ValueConversion/ConverterFactory.cs
+++ b/Sally7/ValueConversion/ConverterFactory.cs
@@ -3,9 +3,9 @@ using System.Runtime.CompilerServices;
 
 namespace Sally7.ValueConversion
 {
-    public delegate int ConvertToS7<TValue>(in TValue? value, in int length, in Span<byte> output);
+    public delegate int ConvertToS7<TValue>(TValue? value, int length, Span<byte> output);
 
-    public delegate void ConvertFromS7<TValue>(ref TValue? value, in ReadOnlySpan<byte> input, in int length);
+    public delegate void ConvertFromS7<TValue>(ref TValue? value, ReadOnlySpan<byte> input, int length);
 
     internal static class ConverterFactory
     {

--- a/Sally7/ValueConversion/FromS7Conversions.cs
+++ b/Sally7/ValueConversion/FromS7Conversions.cs
@@ -60,13 +60,13 @@ namespace Sally7.ValueConversion
             throw new NotImplementedException();
         }
 
-        private static void ConvertToLong(ref long value, in ReadOnlySpan<byte> input, in int length)
+        private static void ConvertToLong(ref long value, ReadOnlySpan<byte> input, int length)
         {
             value = (long) (uint) (input[0] << 24 | input[1] << 16 | input[2] << 8 | input[3]) << 32 |
                 (uint) (input[4] << 24 | input[5] << 16 | input[6] << 8 | input[7]);
         }
 
-        private static void ConvertToLongArray<TTarget>(ref long[]? value, in ReadOnlySpan<byte> input, in int length)
+        private static void ConvertToLongArray<TTarget>(ref long[]? value, ReadOnlySpan<byte> input, int length)
         {
             value ??= Unsafe.As<long[]>(Array.CreateInstance(typeof(TTarget).GetElementType(), length));
 
@@ -74,12 +74,12 @@ namespace Sally7.ValueConversion
                 ConvertToLong(ref value![i], input.Slice(i * sizeof(long)), 1);
         }
 
-        private static void ConvertToInt(ref int value, in ReadOnlySpan<byte> input, in int length)
+        private static void ConvertToInt(ref int value, ReadOnlySpan<byte> input, int length)
         {
             value = input[0] << 24 | input[1] << 16 | input[2] << 8 | input[3];
         }
 
-        private static void ConvertToIntArray<TTarget>(ref int[]? value, in ReadOnlySpan<byte> input, in int length)
+        private static void ConvertToIntArray<TTarget>(ref int[]? value, ReadOnlySpan<byte> input, int length)
         {
             value ??= Unsafe.As<int[]>(Array.CreateInstance(typeof(TTarget).GetElementType(), length));
 
@@ -87,12 +87,12 @@ namespace Sally7.ValueConversion
                 ConvertToInt(ref value![i], input.Slice(i * sizeof(int)), 1);
         }
 
-        private static void ConvertToShort(ref short value, in ReadOnlySpan<byte> input, in int length)
+        private static void ConvertToShort(ref short value, ReadOnlySpan<byte> input, int length)
         {
             value = (short) (input[0] << 8 | input[1]);
         }
 
-        private static void ConvertToShortArray<TTarget>(ref short[]? value, in ReadOnlySpan<byte> input, in int length)
+        private static void ConvertToShortArray<TTarget>(ref short[]? value, ReadOnlySpan<byte> input, int length)
         {
             value ??= Unsafe.As<short[]>(Array.CreateInstance(typeof(TTarget).GetElementType(), length));
 
@@ -100,24 +100,24 @@ namespace Sally7.ValueConversion
                 ConvertToShort(ref value![i], input.Slice(i * sizeof(short)), 1);
         }
 
-        private static void ConvertToByte(ref byte value, in ReadOnlySpan<byte> input, in int length)
+        private static void ConvertToByte(ref byte value, ReadOnlySpan<byte> input, int length)
         {
             value = input[0];
         }
 
-        private static void ConvertToByteArray<TTarget>(ref byte[]? value, in ReadOnlySpan<byte> input, in int length)
+        private static void ConvertToByteArray<TTarget>(ref byte[]? value, ReadOnlySpan<byte> input, int length)
         {
             value ??= Unsafe.As<byte[]>(Array.CreateInstance(typeof(TTarget).GetElementType(), length));
 
             input.CopyTo(value);
         }
 
-        private static void ConvertToBoolArray(ref bool[]? value, in ReadOnlySpan<byte> input, in int length)
+        private static void ConvertToBoolArray(ref bool[]? value, ReadOnlySpan<byte> input, int length)
         {
             value = new BitArray(input.Slice(0, (length + 7) / 8).ToArray()).Cast<bool>().Take(length).ToArray();
         }
 
-        private static void ConvertToString(ref string? value, in ReadOnlySpan<byte> input, in int length)
+        private static void ConvertToString(ref string? value, ReadOnlySpan<byte> input, int length)
         {
             value = Encoding.ASCII.GetString(input.Slice(2, input[1]).ToArray());
         }

--- a/Sally7/ValueConversion/ToS7Conversions.cs
+++ b/Sally7/ValueConversion/ToS7Conversions.cs
@@ -59,7 +59,7 @@ namespace Sally7.ValueConversion
             throw new NotImplementedException();
         }
 
-        private static int ConvertFromLong(in long value, in int length, in Span<byte> output)
+        private static int ConvertFromLong(long value, int length, Span<byte> output)
         {
             ConvertFromInt((int) (value >> 32), 1, output);
             ConvertFromInt((int) value, 1, output.Slice(sizeof(int)));
@@ -67,7 +67,7 @@ namespace Sally7.ValueConversion
             return sizeof(long);
         }
 
-        private static int ConvertFromLongArray(in long[]? value, in int length, in Span<byte> output)
+        private static int ConvertFromLongArray(long[]? value, int length, Span<byte> output)
         {
             if (value == null) throw new ArgumentNullException(nameof(value), "Value can't be null.");
 
@@ -77,7 +77,7 @@ namespace Sally7.ValueConversion
             return value.Length * sizeof(long);
         }
 
-        private static int ConvertFromInt(in int value, in int length, in Span<byte> output)
+        private static int ConvertFromInt(int value, int length, Span<byte> output)
         {
             output[0] = (byte) (value >> 24);
             output[1] = (byte) (value >> 16);
@@ -87,7 +87,7 @@ namespace Sally7.ValueConversion
             return sizeof(int);
         }
 
-        private static int ConvertFromIntArray(in int[]? value, in int length, in Span<byte> output)
+        private static int ConvertFromIntArray(int[]? value, int length, Span<byte> output)
         {
             if (value == null) throw new ArgumentNullException(nameof(value), "Value can't be null.");
 
@@ -97,7 +97,7 @@ namespace Sally7.ValueConversion
             return value.Length * sizeof(int);
         }
 
-        private static int ConvertFromShort(in short value, in int length, in Span<byte> output)
+        private static int ConvertFromShort(short value, int length, Span<byte> output)
         {
             output[0] = (byte) (value >> 8);
             output[1] = (byte) value;
@@ -105,7 +105,7 @@ namespace Sally7.ValueConversion
             return sizeof(short);
         }
 
-        private static int ConvertFromShortArray(in short[]? value, in int length, in Span<byte> output)
+        private static int ConvertFromShortArray(short[]? value, int length, Span<byte> output)
         {
             if (value == null) throw new ArgumentNullException(nameof(value), "Value can't be null.");
 
@@ -115,14 +115,14 @@ namespace Sally7.ValueConversion
             return value.Length * sizeof(short);
         }
 
-        private static int ConvertFromByte(in byte value, in int length, in Span<byte> output)
+        private static int ConvertFromByte(byte value, int length, Span<byte> output)
         {
             output[0] = value;
 
             return sizeof(byte);
         }
 
-        private static int ConvertFromByteArray(in byte[]? value, in int length, in Span<byte> output)
+        private static int ConvertFromByteArray(byte[]? value, int length, Span<byte> output)
         {
             if (value == null) throw new ArgumentNullException(nameof(value), "Value can't be null.");
 
@@ -131,7 +131,7 @@ namespace Sally7.ValueConversion
             return value.Length;
         }
 
-        private static int ConvertFromBoolArray(in bool[]? value, in int length, in Span<byte> output)
+        private static int ConvertFromBoolArray(bool[]? value, int length, Span<byte> output)
         {
             if (value == null) throw new ArgumentNullException(nameof(value), "Value can't be null.");
 
@@ -143,7 +143,7 @@ namespace Sally7.ValueConversion
             return byteArray.Length;
         }
 
-        private static int ConvertFromString(in string? value, in int length, in Span<byte> output)
+        private static int ConvertFromString(string? value, int length, Span<byte> output)
         {
             if (value == null)
             {


### PR DESCRIPTION
In C# structs are passed to methods by value, so they are "readonly" by construction. Hence there's no need to add the `in` modifier.

`in` may harm perf, as the arguments can't be passed in CPU-registers, rather they have to be passed via stack-allocated memory, which is way more overhead than simple passing by registers.

`in` is only useful when `readonly struct`s need to be passed around, so that C# compiler doesn't need to create a defensive copy.

This PR removes all unnecessary uses of `in`.
Note: technically this is a breaking change, but as the version of the project (according to SemVer) is below 1.0.0 this shouldn't be a problem.