### PR TITLE
Plumbed in CancellationTokens

### DIFF
--- a/Sally7/Internal/SocketTpktReader.desktop.cs
+++ b/Sally7/Internal/SocketTpktReader.desktop.cs
@@ -20,7 +20,7 @@ namespace Sally7.Internal
             awaitable = new SocketAwaitable(args);
         }
 
-        public async ValueTask<int> ReadAsync(Memory<byte> message, CancellationToken _)
+        public async ValueTask<int> ReadAsync(Memory<byte> message, CancellationToken cancellationToken)
         {
             if (!MemoryMarshal.TryGetArray<byte>(message, out var segment))
             {
@@ -37,6 +37,7 @@ namespace Sally7.Internal
                     args.SetBuffer(segment.Offset + count, TpktSize - count);
                 }
 
+                cancellationToken.ThrowIfCancellationRequested();
                 await socket.ReceiveAsync(awaitable);
 
                 if (args.BytesTransferred <= 0)
@@ -52,6 +53,7 @@ namespace Sally7.Internal
 
             while (count < receivedLength)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 args.SetBuffer(segment.Offset + count, receivedLength - count);
                 await socket.ReceiveAsync(awaitable);
 

--- a/Sally7/Internal/SocketTpktReader.desktop.cs
+++ b/Sally7/Internal/SocketTpktReader.desktop.cs
@@ -1,8 +1,9 @@
-﻿#if !NETSTANDARD2_1_OR_GREATER && !NET5_0_OR_GREATER
+#if !NETSTANDARD2_1_OR_GREATER && !NET5_0_OR_GREATER
 
 using System;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Sally7.Internal
@@ -19,7 +20,7 @@ namespace Sally7.Internal
             awaitable = new SocketAwaitable(args);
         }
 
-        public async ValueTask<int> ReadAsync(Memory<byte> message)
+        public async ValueTask<int> ReadAsync(Memory<byte> message, CancellationToken _)
         {
             if (!MemoryMarshal.TryGetArray<byte>(message, out var segment))
             {

--- a/Sally7/Internal/SocketTpktReader.netcore.cs
+++ b/Sally7/Internal/SocketTpktReader.netcore.cs
@@ -1,7 +1,8 @@
-﻿#if NETSTANDARD2_1 || NET5_0_OR_GREATER
+#if NETSTANDARD2_1 || NET5_0_OR_GREATER
 
 using System;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Sally7.Internal
@@ -10,7 +11,7 @@ namespace Sally7.Internal
     {
         public SocketTpktReader(Socket socket) => this.socket = socket;
 
-        public async ValueTask<int> ReadAsync(Memory<byte> message)
+        public async ValueTask<int> ReadAsync(Memory<byte> message, CancellationToken cancellationToken)
         {
             int count = 0;
             Memory<byte> buffer = message.Slice(0, TpktSize);
@@ -21,7 +22,7 @@ namespace Sally7.Internal
                     buffer = message[count..TpktSize];
                 }
 
-                int read = await socket.ReceiveAsync(buffer, SocketFlags.None).ConfigureAwait(false);
+                int read = await socket.ReceiveAsync(buffer, SocketFlags.None, cancellationToken).ConfigureAwait(false);
 
                 if (read <= 0)
                 {
@@ -37,7 +38,7 @@ namespace Sally7.Internal
             while (count < receivedLength)
             {
                 buffer = message[count..receivedLength];
-                int read = await socket.ReceiveAsync(buffer, SocketFlags.None).ConfigureAwait(false);
+                int read = await socket.ReceiveAsync(buffer, SocketFlags.None, cancellationToken).ConfigureAwait(false);
 
                 if (read <= 0)
                 {

--- a/Sally7/RequestExecutor/IRequestExecutor.cs
+++ b/Sally7/RequestExecutor/IRequestExecutor.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Sally7.RequestExecutor
@@ -22,7 +23,8 @@ namespace Sally7.RequestExecutor
         /// </remarks>
         /// <param name="request">The <see cref="ReadOnlyMemory{T}"/> that contains the request.</param>
         /// <param name="response">The <see cref="Memory{T}"/> that will be used to store the response.</param>
+        /// <param name="cancellationToken">Cancellationtoken.</param>
         /// <returns>The response as a slice of the supplied <paramref name="response"/> parameter.</returns>
-        ValueTask<Memory<byte>> PerformRequest(ReadOnlyMemory<byte> request, Memory<byte> response);
+        ValueTask<Memory<byte>> PerformRequest(ReadOnlyMemory<byte> request, Memory<byte> response, CancellationToken cancellationToken = default);
     }
 }

--- a/Sally7/S7Connection.cs
+++ b/Sally7/S7Connection.cs
@@ -107,6 +107,7 @@ namespace Sally7
 #if NET5_0_OR_GREATER
             await TcpClient.ConnectAsync(host, IsoOverTcpPort, cancellationToken).ConfigureAwait(false);
 #else
+            cancellationToken.ThrowIfCancellationRequested();
             await TcpClient.ConnectAsync(host, IsoOverTcpPort).ConfigureAwait(false);
 #endif
             var stream = TcpClient.GetStream();
@@ -116,6 +117,7 @@ namespace Sally7
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
             await stream.WriteAsync(buffer, 0, S7ConnectionHelpers.BuildConnectRequest(buffer, sourceTsap, destinationTsap), cancellationToken).ConfigureAwait(false);
 #else
+            cancellationToken.ThrowIfCancellationRequested();
             await stream.WriteAsync(buffer, 0, S7ConnectionHelpers.BuildConnectRequest(buffer, sourceTsap, destinationTsap)).ConfigureAwait(false);
 #endif
             var length = await ReadTpktAsync(stream, buffer, cancellationToken).ConfigureAwait(false);
@@ -124,6 +126,7 @@ namespace Sally7
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
             await stream.WriteAsync(buffer, 0, S7ConnectionHelpers.BuildCommunicationSetup(buffer), cancellationToken).ConfigureAwait(false);
 #else
+            cancellationToken.ThrowIfCancellationRequested();
             await stream.WriteAsync(buffer, 0, S7ConnectionHelpers.BuildCommunicationSetup(buffer)).ConfigureAwait(false);
 #endif
             length = await ReadTpktAsync(stream, buffer, cancellationToken).ConfigureAwait(false);
@@ -188,6 +191,7 @@ namespace Sally7
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
             var len = await stream.ReadAsync(buffer, 0, 4, cancellationToken).ConfigureAwait(false);
 #else
+            cancellationToken.ThrowIfCancellationRequested();
             var len = await stream.ReadAsync(buffer, 0, 4).ConfigureAwait(false);
 #endif
             if (len < 4)
@@ -203,6 +207,7 @@ namespace Sally7
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
             len = await stream.ReadAsync(buffer, 4, msgLen, cancellationToken).ConfigureAwait(false);
 #else
+            cancellationToken.ThrowIfCancellationRequested();
             len = await stream.ReadAsync(buffer, 4, msgLen).ConfigureAwait(false);
 #endif
             if (len != msgLen)

--- a/Sally7/S7Connection.cs
+++ b/Sally7/S7Connection.cs
@@ -139,7 +139,8 @@ namespace Sally7
             ArrayPool<byte>.Shared.Return(buffer);
         }
 
-        public async Task ReadAsync(CancellationToken cancellationToken = default, params IDataItem[] dataItems)
+        public Task ReadAsync(params IDataItem[] dataItems) => ReadAsync(dataItems, CancellationToken.None);
+        public async Task ReadAsync(IDataItem[] dataItems, CancellationToken cancellationToken = default)
         {
             IRequestExecutor executor = GetExecutorOrThrow();
 
@@ -154,7 +155,8 @@ namespace Sally7
             S7ConnectionHelpers.ParseReadResponse(response.Span, dataItems);
         }
 
-        public async Task WriteAsync(CancellationToken cancellationToken = default, params IDataItem[] dataItems)
+        public Task WriteAsync(params IDataItem[] dataItems) => WriteAsync(dataItems, CancellationToken.None);
+        public async Task WriteAsync(IDataItem[] dataItems, CancellationToken cancellationToken = default)
         {
             IRequestExecutor executor = GetExecutorOrThrow();
 


### PR DESCRIPTION
For .NET 5 onwards cancellation is supported on all operations.
For .NET Standard 2.1 (onwards) most operations support cancellation.

Strictly speaking this change is a binary breaking change, as cancellation tokens are added as additional argument to the methods.
Shouldn't be a problem, as version of Sally7 is below 1.0.0 according to SemVer.
Besides that I doubt that anyone won't recompile the project here after updating the reference.

Except for S7Connection `WriteAsync` and `ReadAsync` new overloads were added, in order to keep the same "usage behavor" of the overloads, as `params` must be the last argument and usually CancellationTokens are also set last.
So this code still works as expected:
```c#
IDataItem item0 = null!;
IDataItem item1 = null!;

await s7Connection.ReadAsync(item0, item1);

IDataItem[] dataItems = { item0, item1 };
await s7Connection.ReadAsync(dataItems);

CancellationToken cancellationToken = default;
await s7Connection.ReadAsync(dataItems, cancellationToken);
```

---

I used this overloads in a work project already, but added Sally7 therefore as git submodule. So I'd appreciate that this change can be merged, so that the official package could be referenced (and the submodule go away).