### PR TITLE
fix: Prevent exception on return of job ID to disposed pool

### DIFF
--- a/Sally7.Tests/RequestExecutor/JobPoolTests.cs
+++ b/Sally7.Tests/RequestExecutor/JobPoolTests.cs
@@ -1,0 +1,33 @@
+using System.Threading.Channels;
+using Sally7.RequestExecutor;
+
+namespace Sally7.Tests.RequestExecutor;
+
+public class JobPoolTests
+{
+    [Fact]
+    public async Task RentJobIdAsync_Throws_If_Disposed_And_Depleted()
+    {
+        // Arrange
+        var sut = new JobPool(1);
+        sut.Dispose();
+        _ = await sut.RentJobIdAsync(CancellationToken.None); // Empty the pool
+
+        // Act
+        // Assert
+        await Should.ThrowAsync<ChannelClosedException>(() => sut.RentJobIdAsync(CancellationToken.None).AsTask());
+    }
+
+    [Fact]
+    public void ReturnJobId_Does_Not_Throw_If_Disposed()
+    {
+        // Arrange
+        var sut = new JobPool(1);
+        var jobId = sut.RentJobIdAsync(CancellationToken.None).Result;
+        sut.Dispose();
+
+        // Act
+        // Assert
+        sut.ReturnJobId(jobId);
+    }
+}

--- a/Sally7/RequestExecutor/ConcurrentRequestExecutor.cs
+++ b/Sally7/RequestExecutor/ConcurrentRequestExecutor.cs
@@ -192,7 +192,7 @@ namespace Sally7.RequestExecutor
         {
             private readonly Channel<int> _jobIdPool;
             private readonly Request[] _requests;
-            private volatile bool _disposed;
+            private bool _disposed;
 
             public JobPool(int maxNumberOfConcurrentRequests)
             {
@@ -212,7 +212,7 @@ namespace Sally7.RequestExecutor
 
             public void Dispose()
             {
-                _disposed = true;
+                Volatile.Write(ref _disposed, true);
                 _jobIdPool.Writer.Complete();
             }
 
@@ -220,7 +220,7 @@ namespace Sally7.RequestExecutor
 
             public void ReturnJobId(int jobId)
             {
-                if (!_jobIdPool.Writer.TryWrite(jobId) && !_disposed)
+                if (!_jobIdPool.Writer.TryWrite(jobId) && !Volatile.Read(ref _disposed))
                 {
                     Sally7Exception.ThrowFailedToReturnJobIDToPool(jobId);
                 }

--- a/Sally7/RequestExecutor/JobPool.cs
+++ b/Sally7/RequestExecutor/JobPool.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Sally7.RequestExecutor;
+
+internal class JobPool : IDisposable
+{
+    private readonly Channel<int> _jobIdPool;
+    private readonly Request[] _requests;
+    private bool _disposed;
+
+    public JobPool(int maxNumberOfConcurrentRequests)
+    {
+        _jobIdPool = Channel.CreateBounded<int>(maxNumberOfConcurrentRequests);
+        _requests = new Request[maxNumberOfConcurrentRequests];
+
+        for (int i = 0; i < maxNumberOfConcurrentRequests; ++i)
+        {
+            if (!_jobIdPool.Writer.TryWrite(i + 1))
+            {
+                Sally7Exception.ThrowFailedToInitJobPool();
+            }
+
+            _requests[i] = new Request();
+        }
+    }
+
+    public void Dispose()
+    {
+        Volatile.Write(ref _disposed, true);
+        _jobIdPool.Writer.Complete();
+    }
+
+    public ValueTask<int> RentJobIdAsync(CancellationToken cancellationToken) => _jobIdPool.Reader.ReadAsync(cancellationToken);
+
+    public void ReturnJobId(int jobId)
+    {
+        if (!_jobIdPool.Writer.TryWrite(jobId) && !Volatile.Read(ref _disposed))
+        {
+            Sally7Exception.ThrowFailedToReturnJobIDToPool(jobId);
+        }
+    }
+
+    [DebuggerNonUserCode]
+    public Request GetRequest(int jobId) => _requests[jobId - 1];
+
+    public void SetBufferForRequest(int jobId, Memory<byte> buffer)
+    {
+        Request req = GetRequest(jobId);
+        req.Reset();
+        req.SetBuffer(buffer);
+    }
+}

--- a/Sally7/RequestExecutor/Request.cs
+++ b/Sally7/RequestExecutor/Request.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Sally7.RequestExecutor;
+
+internal class Request : INotifyCompletion
+{
+    private static readonly Action Sentinel = () => { };
+
+    private Memory<byte> _buffer;
+
+    public bool IsCompleted { get; private set; }
+    private int _length;
+    private Action? _continuation = Sentinel;
+
+    public Memory<byte> Buffer => _buffer;
+
+    public void Complete(int length)
+    {
+        this._length = length;
+        IsCompleted = true;
+
+        var prev = _continuation ?? Interlocked.CompareExchange(ref _continuation, Sentinel, null);
+        prev?.Invoke();
+    }
+
+    public Memory<byte> GetResult()
+    {
+        return _buffer.Slice(0, _length);
+    }
+
+    public Request GetAwaiter() => this;
+
+    public void OnCompleted(Action continuation)
+    {
+        if (this._continuation == Sentinel ||
+            Interlocked.CompareExchange(ref this._continuation, continuation, null) == Sentinel)
+        {
+            continuation.Invoke();
+        }
+    }
+
+    public void Reset()
+    {
+        _continuation = null;
+        IsCompleted = false;
+    }
+
+    public void SetBuffer(Memory<byte> buffer)
+    {
+        this._buffer = buffer;
+    }
+}


### PR DESCRIPTION
Currently when the connection is disposed and requests are still in the queue they will except because the job ID can no longer be returned to the pool. Making the exception on `ReturnJobId` conditional on a new `_disposed` flag prevents the exception from being thrown, but it does permit 'successful' returns to a disposed pool.

@gfoidl please let me know what you think. This is hitting us in production now, so I'll probably merge this quickly.