### PR TITLE
Hotfix conversion of float/double

### DIFF
--- a/Sally7.Tests/FromPlcConverterTests.cs
+++ b/Sally7.Tests/FromPlcConverterTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Sally7.Tests
 {
-    public class ValueTypeConversionTests
+    public class FromPlcConverterTests
     {
         [Theory]
         [InlineData(0)]

--- a/Sally7.Tests/TestValues.cs
+++ b/Sally7.Tests/TestValues.cs
@@ -1,0 +1,106 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Sally7.Tests;
+
+internal static class TestValues
+{
+    public static IEnumerable<byte> ByteData =>
+        Enumerable.Range(byte.MinValue, byte.MaxValue).Select(x => (byte)x);
+
+    public static IEnumerable<sbyte> SByteData =>
+        Enumerable.Range(sbyte.MinValue, sbyte.MaxValue).Select(x => (sbyte)x);
+
+
+    public static IEnumerable<short> Int16Data => ShortValues;
+
+    public static IEnumerable<ushort> UInt16Data =>
+        ShortValues.Select(x => (ushort)x);
+
+    public static IEnumerable<int> Int32Data => UIntValues.Select(x => (int)x);
+
+    public static IEnumerable<uint> UInt32Data => UIntValues;
+
+    public static IEnumerable<float> SingleData
+    {
+        get
+        {
+            float[] values =
+            [
+                0,
+                1,
+                0.1f,
+                123.45f,
+                float.MinValue,
+                float.MaxValue,
+            ];
+
+            return values;
+        }
+    }
+
+    public static IEnumerable<long> Int64Data => ULongValues.Select(x => (long) x);
+
+    public static IEnumerable<ulong> UInt64Data => ULongValues;
+
+    public static IEnumerable<double> DoubleData
+    {
+        get
+        {
+            double[] values =
+            [
+                0,
+                1,
+                0.1,
+                123.45,
+                0.0000001,
+                (double) ulong.MaxValue * 33,
+                double.MinValue,
+                double.MaxValue,
+            ];
+
+            return values;
+        }
+    }
+
+    private static readonly short[] ShortValues =
+    [
+        0,
+        1,
+        123,
+        12345,
+        -1,
+        -123,
+        -12345,
+        1 << 8,
+        1 | 2 << 8,
+        short.MinValue,
+        short.MaxValue
+    ];
+
+    private static readonly uint[] UIntValues =
+    [
+        uint.MinValue,
+        uint.MaxValue,
+        1,
+        123,
+        12345,
+        1 << 8,
+        1 << 16,
+        1 << 24,
+        1 | 2 << 8,
+        1 | 2 << 8 | 3 << 16,
+        1 | 2 << 8 | 3 << 24,
+        1 | 2 << 8 | 3 << 16 | 4 << 24,
+        0xf,
+        0xf << 8,
+        0xf << 16,
+        0xf << 24,
+    ];
+
+    private static readonly ulong[] ULongValues = UIntValues.Select(x => (ulong)x)
+        .SelectMany(x => new[] { x, x << 8, x << 16, x << 24, x << 32 })
+        .Concat(UIntValues.SelectMany(_ => UIntValues, (a, b) => (ulong)a << 32 | b))
+        .Concat(UIntValues.SelectMany(_ => UIntValues, (a, b) => a | (ulong)b << 32)).Distinct().ToArray();
+}

--- a/Sally7.Tests/TestValuesDataAttribute.cs
+++ b/Sally7.Tests/TestValuesDataAttribute.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Sally7.Tests;
+
+internal sealed class TestValuesDataAttribute : DataAttribute
+{
+    public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+    {
+        var paramType = testMethod.GetParameters()[0].ParameterType;
+        var dataProperty = typeof(TestValues).GetProperty($"{paramType.Name}Data") ??
+            throw new ArgumentException($"No data available for type {paramType}");
+
+        var data = dataProperty.GetValue(null) as IEnumerable ??
+            throw new NotSupportedException($"Data from {dataProperty} could not be converted to {nameof(IEnumerable)}.");
+
+        foreach (var value in data) yield return [value];
+    }
+}

--- a/Sally7.Tests/ToPlcConverterTests.cs
+++ b/Sally7.Tests/ToPlcConverterTests.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using Sally7.ValueConversion;
+using Xunit;
+
+namespace Sally7.Tests;
+
+public static class ToPlcConverterTests
+{
+    public class Elements
+    {
+        [Theory]
+        [TestValuesData]
+        public void ConvertByteToPlc(byte value)
+        {
+            // Arrange
+            var converter = ConverterFactory.GetToPlcConverter<byte>();
+            var buffer = new byte[sizeof(byte)];
+
+            // Act
+            converter(value, 1, buffer);
+
+            // Assert
+            Assert.Equal([value], buffer);
+        }
+
+        [Theory]
+        [TestValuesData]
+        public void ConvertSByteToPlc(sbyte value)
+        {
+            // Arrange
+            var converter = ConverterFactory.GetToPlcConverter<sbyte>();
+            var buffer = new byte[sizeof(sbyte)];
+
+            // Act
+            converter(value, 1, buffer);
+
+            // Assert
+            Assert.Equal([(byte)value], buffer);
+        }
+
+        [Theory]
+        [TestValuesData]
+        public void ConvertInt16ToPlc(short value)
+        {
+            TestConvertToPlc(value, sizeof(short), BitConverter.GetBytes);
+        }
+
+        [Theory]
+        [TestValuesData]
+        public void ConvertUInt16ToPlc(ushort value)
+        {
+            TestConvertToPlc(value, sizeof(ushort), BitConverter.GetBytes);
+        }
+
+        [Theory]
+        [TestValuesData]
+        public void ConvertInt32ToPlc(int value)
+        {
+            TestConvertToPlc(value, sizeof(int), BitConverter.GetBytes);
+        }
+
+        [Theory]
+        [TestValuesData]
+        public void ConvertUInt32ToPlc(uint value)
+        {
+            TestConvertToPlc(value, sizeof(uint), BitConverter.GetBytes);
+        }
+
+        [Theory]
+        [TestValuesData]
+        public void ConvertSingleToPlc(float value)
+        {
+            TestConvertToPlc(value, sizeof(float), BitConverter.GetBytes);
+        }
+
+        [Theory]
+        [TestValuesData]
+        public void ConvertInt64ToPlc(long value)
+        {
+            TestConvertToPlc(value, sizeof(long), BitConverter.GetBytes);
+        }
+
+        [Theory]
+        [TestValuesData]
+        public void ConvertUInt64ToPlc(ulong value)
+        {
+            TestConvertToPlc(value, sizeof(ulong), BitConverter.GetBytes);
+        }
+
+        [Theory]
+        [TestValuesData]
+        public void ConvertDoubleToPlc(double value)
+        {
+            TestConvertToPlc(value, sizeof(double), BitConverter.GetBytes);
+        }
+
+        private static void TestConvertToPlc<T>(T value, int size, Func<T, byte[]> getBytes)
+        {
+            // Arrange
+            var converter = ConverterFactory.GetToPlcConverter<T>();
+            var buffer = new byte[size];
+
+            // Act
+            converter(value, 1, buffer);
+
+            // Assert
+            var bytes = getBytes.Invoke(value);
+            if (BitConverter.IsLittleEndian) Array.Reverse(bytes);
+
+            Assert.Equal(bytes, buffer);
+        }
+    }
+
+    public class Arrays
+    {
+        [Theory]
+        [TestValuesData]
+        public void ConvertFloatArrToPlc(float value)
+        {
+            // Arrange
+            var converter = ConverterFactory.GetToPlcConverter<float[]>();
+            var buffer = new byte[sizeof(float)];
+
+            // Act
+            converter([value], 1, buffer);
+
+            // Assert
+            var bytes = BitConverter.GetBytes(value);
+            if (BitConverter.IsLittleEndian) Array.Reverse(bytes);
+
+            Assert.Equal(bytes, buffer);
+        }
+    }
+}

--- a/Sally7.Tests/ToPlcConverterTests.cs
+++ b/Sally7.Tests/ToPlcConverterTests.cs
@@ -13,7 +13,7 @@ public static class ToPlcConverterTests
         public void ConvertByteToPlc(byte value)
         {
             // Arrange
-            var converter = ConverterFactory.GetToPlcConverter<byte>();
+            var converter = ConverterFactory.GetToPlcConverter<byte>(1);
             var buffer = new byte[sizeof(byte)];
 
             // Act
@@ -28,7 +28,7 @@ public static class ToPlcConverterTests
         public void ConvertSByteToPlc(sbyte value)
         {
             // Arrange
-            var converter = ConverterFactory.GetToPlcConverter<sbyte>();
+            var converter = ConverterFactory.GetToPlcConverter<sbyte>(1);
             var buffer = new byte[sizeof(sbyte)];
 
             // Act
@@ -97,7 +97,7 @@ public static class ToPlcConverterTests
         private static void TestConvertToPlc<T>(T value, int size, Func<T, byte[]> getBytes)
         {
             // Arrange
-            var converter = ConverterFactory.GetToPlcConverter<T>();
+            var converter = ConverterFactory.GetToPlcConverter<T>(1);
             var buffer = new byte[size];
 
             // Act
@@ -118,7 +118,7 @@ public static class ToPlcConverterTests
         public void ConvertFloatArrToPlc(float value)
         {
             // Arrange
-            var converter = ConverterFactory.GetToPlcConverter<float[]>();
+            var converter = ConverterFactory.GetToPlcConverter<float[]>(1);
             var buffer = new byte[sizeof(float)];
 
             // Act

--- a/Sally7/ValueConversion/ConverterFactory.cs
+++ b/Sally7/ValueConversion/ConverterFactory.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace Sally7.ValueConversion
 {
-    public delegate int ConvertToS7<TValue>(TValue? value, int length, Span<byte> output);
+    public delegate int ConvertToS7<TValue>(in TValue? value, int length, Span<byte> output);
 
     public delegate void ConvertFromS7<TValue>(ref TValue? value, ReadOnlySpan<byte> input, int length);
 

--- a/Sally7/ValueConversion/ToS7Conversions.cs
+++ b/Sally7/ValueConversion/ToS7Conversions.cs
@@ -61,7 +61,7 @@ namespace Sally7.ValueConversion
         {
             if (value == null) throw new ArgumentNullException(nameof(value), "Value can't be null.");
 
-            return BufferHelper.CopyAndAlign64Bit(Unsafe.As<long[], byte[]>(ref value), output, length);
+            return BufferHelper.CopyAndAlign64Bit(Unsafe.As<long[], byte[]>(ref Unsafe.AsRef(value)), output, length);
         }
 
         private static int ConvertFromInt(in int value, int length, Span<byte> output)
@@ -75,7 +75,7 @@ namespace Sally7.ValueConversion
         {
             if (value == null) throw new ArgumentNullException(nameof(value), "Value can't be null.");
 
-            return BufferHelper.CopyAndAlign32Bit(Unsafe.As<int[], byte[]>(ref value), output, length);
+            return BufferHelper.CopyAndAlign32Bit(Unsafe.As<int[], byte[]>(ref Unsafe.AsRef(value)), output, length);
         }
 
         private static int ConvertFromShort(in short value, int length, Span<byte> output)
@@ -89,7 +89,7 @@ namespace Sally7.ValueConversion
         {
             if (value == null) throw new ArgumentNullException(nameof(value), "Value can't be null.");
 
-            return BufferHelper.CopyAndAlign16Bit(Unsafe.As<short[], byte[]>(ref value), output, length);
+            return BufferHelper.CopyAndAlign16Bit(Unsafe.As<short[], byte[]>(ref Unsafe.AsRef(value)), output, length);
         }
 
         private static int ConvertFromByte(in byte value, int length, Span<byte> output)

--- a/Sally7/ValueConversion/ToS7Conversions.cs
+++ b/Sally7/ValueConversion/ToS7Conversions.cs
@@ -48,14 +48,14 @@ namespace Sally7.ValueConversion
             throw new NotImplementedException();
         }
 
-        private static int ConvertFromLong(long value, int length, Span<byte> output)
+        private static int ConvertFromLong(in long value, int length, Span<byte> output)
         {
             BinaryPrimitives.WriteInt64BigEndian(output, value);
 
             return sizeof(long);
         }
 
-        private static int ConvertFromLongArray(long[]? value, int length, Span<byte> output)
+        private static int ConvertFromLongArray(in long[]? value, int length, Span<byte> output)
         {
             if (value == null) throw new ArgumentNullException(nameof(value), "Value can't be null.");
 
@@ -65,14 +65,14 @@ namespace Sally7.ValueConversion
             return value.Length * sizeof(long);
         }
 
-        private static int ConvertFromInt(int value, int length, Span<byte> output)
+        private static int ConvertFromInt(in int value, int length, Span<byte> output)
         {
             BinaryPrimitives.WriteInt32BigEndian(output, value);
 
             return sizeof(int);
         }
 
-        private static int ConvertFromIntArray(int[]? value, int length, Span<byte> output)
+        private static int ConvertFromIntArray(in int[]? value, int length, Span<byte> output)
         {
             if (value == null) throw new ArgumentNullException(nameof(value), "Value can't be null.");
 
@@ -82,14 +82,14 @@ namespace Sally7.ValueConversion
             return value.Length * sizeof(int);
         }
 
-        private static int ConvertFromShort(short value, int length, Span<byte> output)
+        private static int ConvertFromShort(in short value, int length, Span<byte> output)
         {
             BinaryPrimitives.WriteInt16BigEndian(output, value);
 
             return sizeof(short);
         }
 
-        private static int ConvertFromShortArray(short[]? value, int length, Span<byte> output)
+        private static int ConvertFromShortArray(in short[]? value, int length, Span<byte> output)
         {
             if (value == null) throw new ArgumentNullException(nameof(value), "Value can't be null.");
 
@@ -99,14 +99,14 @@ namespace Sally7.ValueConversion
             return value.Length * sizeof(short);
         }
 
-        private static int ConvertFromByte(byte value, int length, Span<byte> output)
+        private static int ConvertFromByte(in byte value, int length, Span<byte> output)
         {
             output[0] = value;
 
             return sizeof(byte);
         }
 
-        private static int ConvertFromByteArray(byte[]? value, int length, Span<byte> output)
+        private static int ConvertFromByteArray(in byte[]? value, int length, Span<byte> output)
         {
             if (value == null) throw new ArgumentNullException(nameof(value), "Value can't be null.");
 
@@ -115,7 +115,7 @@ namespace Sally7.ValueConversion
             return value.Length;
         }
 
-        private static int ConvertFromBoolArray(bool[]? value, int length, Span<byte> output)
+        private static int ConvertFromBoolArray(in bool[]? value, int length, Span<byte> output)
         {
             if (value is null)
             {
@@ -152,7 +152,7 @@ namespace Sally7.ValueConversion
             return length;
         }
 
-        private static int ConvertFromString(string? value, int length, Span<byte> output)
+        private static int ConvertFromString(in string? value, int length, Span<byte> output)
         {
             if (value == null)
             {


### PR DESCRIPTION
Fix conversion of single `float`/`double` values to their PLC format. The assumption that the runtime would treat `Action<float>` similarly to `Action<int>` is apparently invalid, as can also be witnessed from [SharpLab](https://sharplab.io/#v2:EYLgtghglgdgNAFxBAzmAPgAQEwEYCwAUJgMwAEOZAwmQN5FmMXmYAsZAsgBQCUdDTAL4DGI5hXYB1AE5QEAUwCSMBF1gIyANwgAbAK7y+9Qk1MVcATi7b9hgNxjhJpmNISyMufIBiOgPYQqgBm/oFaugZGYqaYltYR9o5EgkA==).