### PR TITLE
Add .NET Framework 4.8 and 4.8.1 to project,

### DIFF
--- a/Sally7.Benchmarks/Sally7.Benchmarks.csproj
+++ b/Sally7.Benchmarks/Sally7.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;net48;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net6;net7.0;net8</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>

--- a/Sally7.Tests/RequestExecutor/JobPoolTests.cs
+++ b/Sally7.Tests/RequestExecutor/JobPoolTests.cs
@@ -19,11 +19,11 @@ public class JobPoolTests
     }
 
     [Fact]
-    public void ReturnJobId_Does_Not_Throw_If_Disposed()
+    public async Task ReturnJobId_Does_Not_Throw_If_Disposed()
     {
         // Arrange
         var sut = new JobPool(1);
-        var jobId = sut.RentJobIdAsync(CancellationToken.None).Result;
+        var jobId = await sut.RentJobIdAsync(CancellationToken.None);
         sut.Dispose();
 
         // Act
@@ -32,11 +32,11 @@ public class JobPoolTests
     }
 
     [Fact]
-    public void Dispose_Calls_Dispose_On_Requests()
+    public async Task Dispose_Calls_Dispose_On_Requests()
     {
         // Arrange
         var sut = new JobPool(1);
-        var jobId = sut.RentJobIdAsync(CancellationToken.None).Result;
+        var jobId = await sut.RentJobIdAsync(CancellationToken.None);
         var request = sut.GetRequest(jobId);
 
         // Act

--- a/Sally7.Tests/Sally7.Tests.csproj
+++ b/Sally7.Tests/Sally7.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -15,15 +15,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="7.4.0" />
-    <PackageReference Include="GithubActionsTestLogger" Version="2.3.2">
+    <PackageReference Include="FakeItEasy" Version="8.3.0" />
+    <PackageReference Include="GithubActionsTestLogger" Version="2.4.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Sally7/Sally7.csproj
+++ b/Sally7/Sally7.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net461;net462;net48;net481;netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnablePackageValidation>true</EnablePackageValidation>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
Update Sally7.Test NugetPacket to latest  version so that Transitive packages have no vulnerability anymore. Fix some test in  JobPoolTests.cs